### PR TITLE
Useful if I want to load via webpack like this :

### DIFF
--- a/src/polyglot.js
+++ b/src/polyglot.js
@@ -50,10 +50,10 @@ export default {
             const defaultLanguage = options.defaultLanguage;
             return i18n.getBestLanguage(languagesAvailable, navigatorLanguage, defaultLanguage);
           },
-          getLocale({baseURL = 'i18n', lang = 'auto', ext = 'json'} = {}){
+          getLocale({baseURL = 'i18n', lang = 'auto', ext = '.json'} = {}){
             lang = lang === 'auto' ? this.getLang() : lang;
             if (lang !== options.defaultLanguage) {
-              axios.get(`${baseURL}/${lang}.${ext}`)
+              axios.get(`${baseURL}/${lang}${ext}`)
                 .then(response => {
                   const locale = response.data;
                   this.setLocale({lang, locale});


### PR DESCRIPTION
require(`file-loader?name=i18n/[name].[ext]?x=[hash:6]!../static/i18n/${l}.json`)

=> so it put a hash (for cache refresh), and I specify '' for ext in $polyglot.getLocale

thanks !!